### PR TITLE
Disable ziplist.com

### DIFF
--- a/src/chrome/content/rules/Ziplist.com.xml
+++ b/src/chrome/content/rules/Ziplist.com.xml
@@ -1,6 +1,7 @@
-<ruleset name="Ziplist.com">
+<ruleset name="Ziplist.com" default_off="expired cert">
   <target host="ziplist.com" />
   <target host="www.ziplist.com" />
 
-  <rule from="^http://(?:www\.)?ziplist\.com/" to="https://www.ziplist.com/" />
+  <rule from="^http://(?:www\.)?ziplist\.com/" 
+          to="https://www.ziplist.com/" />
 </ruleset>


### PR DESCRIPTION
Certificate expired in December 2015